### PR TITLE
fix(ci): case-sensitive import for Dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,7 @@ import AdminDashboard from './pages/admin/AdminDashboard';
 import UserDetail from './pages/admin/UserDetail';
 import AdminUsersPage from './pages/admin/users';
 import AppShell from './components/AppShell';
-import Dashboard from './pages/Dashboard';
+import Dashboard from './pages/dashboard';
 import Compose from './pages/Compose';
 import Integrations from './pages/Integrations';
 import Billing from './pages/Billing';


### PR DESCRIPTION
CI fallaba en Linux por import con mayúsculas:
- App.js tenía `./pages/Dashboard`
- El archivo es `frontend/src/pages/dashboard.jsx`

✅ Cambiado a `./pages/dashboard`
Esperado: Build Check verde.

