### PR TITLE
🐛 Fix case-sensitive import error in Dashboard test

### DIFF
--- a/frontend/src/pages/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Dashboard from '../Dashboard';
+import Dashboard from '../dashboard';
 
 // Mock lucide-react icons
 jest.mock('lucide-react', () => {


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #33 - CI error: Can't resolve './pages/Dashboard' en entorno frontend

### 🔍 Problem
The CI build was failing with:
```
Module not found: Error: Can't resolve './pages/Dashboard'
```

### 🎯 Solution
The test file was importing `../Dashboard` (uppercase) but the actual file is named `dashboard.jsx` (lowercase).

Changed:
```javascript
// ❌ Before
import Dashboard from '../Dashboard';

// ✅ After  
import Dashboard from '../dashboard';
```

### ✅ Verification
- Frontend build passes successfully: `npm run build:ci` ✅
- No other imports of Dashboard with incorrect casing found
- Pre-commit checks passed

### 📝 Note
This is a case sensitivity issue that typically manifests in CI environments (Linux) but not in local development (macOS/Windows). The fix ensures consistency across all platforms.

🤖 Generated with [Claude Code](https://claude.ai/code)