### PR TITLE
refactor: use platform limit constants

### DIFF
--- a/roastr-bot/services/twitterService.js
+++ b/roastr-bot/services/twitterService.js
@@ -6,6 +6,7 @@
 const { TwitterApi } = require('twitter-api-v2');
 const logger = require('../utils/logger');
 const filters = require('../utils/filters');
+const { PLATFORM_LIMITS } = require('../../src/config/constants');
 
 class TwitterService {
   constructor(config = {}) {
@@ -221,7 +222,7 @@ class TwitterService {
       }
 
       // Ensure roast text fits Twitter's character limit
-      const maxLength = 280;
+      const maxLength = PLATFORM_LIMITS.twitter.maxLength;
       let tweetText = roastText;
       
       if (tweetText.length > maxLength) {

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -23,16 +23,16 @@ const DEFAULT_TONE = 'sarcastic';
 
 // Platform constraints (character limits)
 const PLATFORM_LIMITS = {
-  twitter: 280,
-  instagram: 2200,
-  facebook: 63206,
-  linkedin: 3000,
-  tiktok: 2200,
-  youtube: 10000,
-  discord: 2000,
-  reddit: 40000,
-  bluesky: 300,
-  default: 1000
+  twitter: { maxLength: 280 },
+  instagram: { maxLength: 2200 },
+  facebook: { maxLength: 63206 },
+  linkedin: { maxLength: 3000 },
+  tiktok: { maxLength: 2200 },
+  youtube: { maxLength: 10000 },
+  discord: { maxLength: 2000 },
+  reddit: { maxLength: 40000 },
+  bluesky: { maxLength: 300 },
+  default: { maxLength: 1000 }
 };
 
 // Comment categories for classification

--- a/src/config/integrations.js
+++ b/src/config/integrations.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const { PLATFORM_LIMITS } = require('./constants');
 
 module.exports = {
   // Control global de integraciones
@@ -104,7 +105,7 @@ module.exports = {
   // Configuración global de filtros
   globalFilters: {
     minCommentLength: parseInt(process.env.GLOBAL_MIN_COMMENT_LENGTH) || 5,
-    maxCommentLength: parseInt(process.env.GLOBAL_MAX_COMMENT_LENGTH) || 280,
+    maxCommentLength: parseInt(process.env.GLOBAL_MAX_COMMENT_LENGTH) || PLATFORM_LIMITS.twitter.maxLength,
     bannedWords: process.env.GLOBAL_BANNED_WORDS?.split(',') || ['spam', 'bot', 'fake'],
     toxicityThreshold: parseFloat(process.env.GLOBAL_TOXICITY_THRESHOLD) || 0.7,
   },

--- a/src/config/platforms.js
+++ b/src/config/platforms.js
@@ -1,16 +1,18 @@
 /**
  * Platform-specific configuration for roast generation
- * 
+ *
  * Centralizes platform constraints, style guides, and formatting rules
  * to improve maintainability and enable dynamic platform support.
- * 
+ *
  * Issue #128: Extract hardcoded platform rules to dedicated config
  */
+
+const { PLATFORM_LIMITS } = require('./constants');
 
 const PLATFORMS = {
   twitter: {
     name: 'Twitter',
-    maxLength: 280,
+    maxLength: PLATFORM_LIMITS.twitter.maxLength,
     supports: {
       hashtags: true,
       mentions: true,
@@ -32,7 +34,7 @@ const PLATFORMS = {
 
   instagram: {
     name: 'Instagram',
-    maxLength: 2200,
+    maxLength: PLATFORM_LIMITS.instagram.maxLength,
     supports: {
       hashtags: true,
       mentions: true,
@@ -54,7 +56,7 @@ const PLATFORMS = {
 
   facebook: {
     name: 'Facebook',
-    maxLength: 63206,
+    maxLength: PLATFORM_LIMITS.facebook.maxLength,
     supports: {
       hashtags: true,
       mentions: true,
@@ -77,7 +79,7 @@ const PLATFORMS = {
 
   linkedin: {
     name: 'LinkedIn',
-    maxLength: 3000,
+    maxLength: PLATFORM_LIMITS.linkedin.maxLength,
     supports: {
       hashtags: true,
       mentions: true,
@@ -100,7 +102,7 @@ const PLATFORMS = {
 
   tiktok: {
     name: 'TikTok',
-    maxLength: 2200,
+    maxLength: PLATFORM_LIMITS.tiktok.maxLength,
     supports: {
       hashtags: true,
       mentions: true,
@@ -122,7 +124,7 @@ const PLATFORMS = {
 
   youtube: {
     name: 'YouTube',
-    maxLength: 10000,
+    maxLength: PLATFORM_LIMITS.youtube.maxLength,
     supports: {
       hashtags: true,
       mentions: false,
@@ -145,7 +147,7 @@ const PLATFORMS = {
 
   discord: {
     name: 'Discord',
-    maxLength: 2000,
+    maxLength: PLATFORM_LIMITS.discord.maxLength,
     supports: {
       mentions: true,
       emojis: true,
@@ -168,7 +170,7 @@ const PLATFORMS = {
 
   reddit: {
     name: 'Reddit',
-    maxLength: 40000,
+    maxLength: PLATFORM_LIMITS.reddit.maxLength,
     supports: {
       mentions: true,
       emojis: true,
@@ -191,7 +193,7 @@ const PLATFORMS = {
 
   bluesky: {
     name: 'Bluesky',
-    maxLength: 300,
+    maxLength: PLATFORM_LIMITS.bluesky.maxLength,
     supports: {
       mentions: true,
       hashtags: true,
@@ -233,7 +235,7 @@ function getPlatformConfig(platformName) {
  */
 function getPlatformLimit(platformName) {
   const config = getPlatformConfig(platformName);
-  return config ? config.maxLength : 1000;
+  return config ? config.maxLength : PLATFORM_LIMITS.default.maxLength;
 }
 
 /**
@@ -243,7 +245,7 @@ function getPlatformLimit(platformName) {
  */
 function getPreferredLength(platformName) {
   const config = getPlatformConfig(platformName);
-  return config ? config.style.preferredLength : 280;
+  return config ? config.style.preferredLength : PLATFORM_LIMITS.twitter.maxLength;
 }
 
 /**
@@ -267,7 +269,7 @@ function getPlatformStyle(platformName) {
   const config = getPlatformConfig(platformName);
   return config ? config.style : {
     tone: 'neutral',
-    preferredLength: 280,
+    preferredLength: PLATFORM_LIMITS.twitter.maxLength,
     emojiUsage: 'moderate'
   };
 }

--- a/src/workers/GenerateReplyWorker.js
+++ b/src/workers/GenerateReplyWorker.js
@@ -3,6 +3,7 @@ const CostControlService = require('../services/costControl');
 const RoastPromptTemplate = require('../services/roastPromptTemplate');
 const transparencyService = require('../services/transparencyService');
 const { mockMode } = require('../config/mockMode');
+const { PLATFORM_LIMITS } = require('../config/constants');
 
 /**
  * Generate Reply Worker
@@ -539,7 +540,7 @@ class GenerateReplyWorker extends BaseWorker {
     let platformConstraints = '';
     switch (platform) {
       case 'twitter':
-        platformConstraints = 'Keep responses under 280 characters for Twitter.';
+        platformConstraints = `Keep responses under ${PLATFORM_LIMITS.twitter.maxLength} characters for Twitter.`;
         break;
       case 'youtube':
         platformConstraints = 'YouTube comment style, can be slightly longer but still concise.';
@@ -573,7 +574,7 @@ class GenerateReplyWorker extends BaseWorker {
    */
   getPlatformConstraint(platform) {
     const constraints = {
-      'twitter': 'RESTRICCIÓN DE PLATAFORMA: Respuesta máxima de 280 caracteres para Twitter.',
+      'twitter': `RESTRICCIÓN DE PLATAFORMA: Respuesta máxima de ${PLATFORM_LIMITS.twitter.maxLength} caracteres para Twitter.`,
       'youtube': 'RESTRICCIÓN DE PLATAFORMA: Estilo de comentario de YouTube, puede ser ligeramente más largo pero mantén la concisión.',
       'instagram': 'RESTRICCIÓN DE PLATAFORMA: Estilo de Instagram, amigable pero con sarcasmo.',
       'facebook': 'RESTRICCIÓN DE PLATAFORMA: Estilo de Facebook, considera audiencia más amplia.',
@@ -610,7 +611,7 @@ class GenerateReplyWorker extends BaseWorker {
     
     switch (platform) {
       case 'twitter':
-        maxLength = 270; // Leave room for mentions/context
+        maxLength = PLATFORM_LIMITS.twitter.maxLength - 10; // Leave room for mentions/context
         break;
       case 'instagram':
         maxLength = 500;
@@ -619,7 +620,7 @@ class GenerateReplyWorker extends BaseWorker {
         maxLength = 1000;
         break;
       default:
-        maxLength = 280;
+        maxLength = PLATFORM_LIMITS.twitter.maxLength;
     }
     
     if (response.length <= maxLength) {

--- a/tests/integration/moderation/full-moderation-flow.test.js
+++ b/tests/integration/moderation/full-moderation-flow.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const { createMockModerationInput, simulateToxicComment, setupTestUserWithPersona, waitForCondition } = require('../../utils/testHelpers');
+const { PLATFORM_LIMITS } = require('../../../src/config/constants');
 
 // Mock services
 jest.mock('../../../src/services/openai', () => ({
@@ -373,7 +374,7 @@ describe('Full Moderation Flow Integration', () => {
 
   describe('Content Approval and Filtering', () => {
     it('should filter out inappropriate roast responses', async () => {
-      const inappropriateRoasts = [
+const inappropriateRoasts = [
         'Tu madre es una...', // Family insults
         'Espero que te mueras', // Death wishes
         'Eres un [slur]', // Slurs
@@ -401,9 +402,9 @@ describe('Full Moderation Flow Integration', () => {
 
     it('should apply platform-specific content rules', async () => {
       const platforms = {
-        twitter: { maxLength: 280, allowHashtags: true },
-        youtube: { maxLength: 10000, allowLinks: true },
-        instagram: { maxLength: 2200, allowEmojis: true }
+        twitter: { maxLength: PLATFORM_LIMITS.twitter.maxLength, allowHashtags: true },
+        youtube: { maxLength: PLATFORM_LIMITS.youtube.maxLength, allowLinks: true },
+        instagram: { maxLength: PLATFORM_LIMITS.instagram.maxLength, allowEmojis: true }
       };
 
       const roast = '¡Vaya comentario! ' + '😂'.repeat(50);

--- a/tests/unit/config/platformLimits.test.js
+++ b/tests/unit/config/platformLimits.test.js
@@ -1,0 +1,7 @@
+const { PLATFORM_LIMITS } = require('../../../src/config/constants');
+
+describe('PLATFORM_LIMITS', () => {
+  test('twitter maxLength is defined', () => {
+    expect(PLATFORM_LIMITS.twitter).toHaveProperty('maxLength', 280);
+  });
+});

--- a/tests/utils/testHelpers.js
+++ b/tests/utils/testHelpers.js
@@ -1,5 +1,6 @@
 // Test utilities for moderation and shield testing
 const { v4: uuidv4 } = require('uuid');
+const { PLATFORM_LIMITS } = require('../../src/config/constants');
 
 /**
  * Creates a mock moderation input for testing
@@ -96,7 +97,7 @@ function setupTestUserWithPersona(overrides = {}) {
       custom_style_prompt: 'Be clever but not mean',
       language_preference: 'es',
       platform_styles: {
-        twitter: { use_hashtags: true, max_length: 280 },
+        twitter: { use_hashtags: true, max_length: PLATFORM_LIMITS.twitter.maxLength },
         youtube: { use_emojis: true }
       }
     },


### PR DESCRIPTION
## Summary
- expose `maxLength` per platform and centralize twitter's 280 character limit
- use `PLATFORM_LIMITS.twitter.maxLength` in twitter service, reply worker, and configs
- add unit test covering the platform limit constants

## Testing
- `npm test tests/unit/config/platformLimits.test.js`
- `npm test tests/integration/moderation/full-moderation-flow.test.js`
- `npm test tests/unit/twitterService.test.js` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b850e6788325ad2608759bab8a52