### PR TITLE
fix(billing): Remove 'free' plan references, update to starter_trial (Issues #488, #489)

### DIFF
--- a/docs/nodes/billing.md
+++ b/docs/nodes/billing.md
@@ -210,7 +210,7 @@ class BillingController {
   "data": {
     "subscription": {
       "user_id": "uuid",
-      "plan": "starter | pro | plus | free",
+      "plan": "starter_trial | starter | pro | plus",
       "status": "active | canceled | past_due",
       "stripe_customer_id": "cus_xxx",
       "stripe_subscription_id": "sub_xxx"
@@ -583,7 +583,7 @@ ENABLE_BILLING=true
 
 ```javascript
 const PLAN_IDS = {
-  FREE: 'free',
+  STARTER_TRIAL: 'starter_trial',
   STARTER: 'starter',
   PRO: 'pro',
   PLUS: 'plus'
@@ -591,11 +591,12 @@ const PLAN_IDS = {
 
 function getPlanFromStripeLookupKey(lookupKey) {
   const mapping = {
+    'plan_starter_trial': PLAN_IDS.STARTER_TRIAL,
     'plan_starter': PLAN_IDS.STARTER,
     'plan_pro': PLAN_IDS.PRO,
     'plan_plus': PLAN_IDS.PLUS
   };
-  return mapping[lookupKey] || PLAN_IDS.FREE;
+  return mapping[lookupKey] || PLAN_IDS.STARTER_TRIAL;
 }
 ```
 

--- a/scripts/validate-flow-billing.js
+++ b/scripts/validate-flow-billing.js
@@ -5,7 +5,7 @@
  * Flow: Usage Request → Check Limits → Allow/Deny → Update Usage
  *
  * Success Criteria:
- * - Free plan enforces 10 roasts/month limit
+ * - Starter trial enforces 10 roasts/month limit
  * - Pro plan enforces 1000 roasts/month limit
  * - Creator Plus plan allows 5000 roasts/month
  * - Limit exceeded returns 403 with upgrade CTA
@@ -41,12 +41,12 @@ const client = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 // Test scenarios for different plans
 const TEST_SCENARIOS = [
   {
-    planId: 'free',
-    userPlan: 'basic', // Users table uses 'basic' instead of 'free'
+    planId: 'starter_trial',
+    userPlan: 'starter_trial', // Starter trial (30 days free with same limits as starter)
     limit: 10,
     testUsage: 11, // One over the limit
     shouldBlock: true,
-    description: 'Free plan exceeds limit'
+    description: 'Starter trial exceeds limit'
   },
   {
     planId: 'pro',


### PR DESCRIPTION
## Summary

Verification and cleanup for issues #488 and #489 - confirmed that 'free' plan data has been successfully migrated to 'starter_trial' model.

**Changes:**
- ✅ Updated `scripts/validate-flow-billing.js` test scenarios: `free` → `starter_trial`
- ✅ Updated `docs/nodes/billing.md` plan mappings and examples
- ✅ Updated `docs/nodes/plan-features.md` plan tiers table, schema, and feature flags

**Context:**
- Migration 025 already eliminated the 'free' plan from database
- Backend code already correctly updated
- This PR removes remaining outdated documentation and test references

**New plan model:**
- Starter Trial - 30 days free (card required, auto-converts to paid Starter)
- Starter - €5/mo
- Pro - €15/mo
- Plus - €50/mo

Closes #488, Closes #489, Related to #678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Starter Trial plan (30-day duration with card requirement) replacing the Free plan tier.
  * Updated plan features and usage limits across billing tiers.
  * Modified billing plan mapping and lookup logic to recognize the new plan tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->