### PR TITLE
fix: Add loose mode to Babel plugins (SPEC 14) (Issue #832)

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -18,8 +18,8 @@ module.exports = (api) => {
     plugins: [
       '@babel/plugin-transform-optional-chaining',
       '@babel/plugin-transform-nullish-coalescing-operator',
-      '@babel/plugin-transform-class-properties',
-      '@babel/plugin-transform-private-methods',
+      ['@babel/plugin-transform-class-properties', { loose: true }],
+      ['@babel/plugin-transform-private-methods', { loose: true }],
     ],
   };
 };


### PR DESCRIPTION
Fixes #832

## Cambios

- Agregado `loose: true` a `@babel/plugin-transform-class-properties`
- Agregado `loose: true` a `@babel/plugin-transform-private-methods`
- Resuelve error de configuración de Babel en tests SPEC 14

## Testing

✅ Tests SPEC 14 deberían pasar ahora
✅ Configuración consistente de Babel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to enable loose mode for improved compilation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->