### PR TITLE
fix(ci): add 'check' script to prevent runner-json-demo timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "frontend:build": "cd frontend && npm run build",
     "frontend:install": "cd frontend && npm install",
     "validate:tests": "node scripts/validate-test-dependencies.js",
+    "check": "jest --config=jest.ci.config.cjs --runInBand --ci --forceExit",
     "test": "jest --verbose",
     "test:ci": "jest --config=jest.ci.config.cjs --runInBand --ci",
     "test:mock": "ENABLE_MOCK_MODE=true jest --config=jest.skipExternal.config.js --verbose",


### PR DESCRIPTION
## Problem

The `runner-json-demo` workflow runs:
```bash
node scripts/test/runner.js check --json
```

The `check` command in `runner.js` looks for a `check` script in `package.json`. When it doesn't exist, it falls back to `npm run test` which runs **all tests** without mock mode.

This causes:
- CI timeouts (>10 minutes)
- Job cancellation (as seen in PR #1004)

## Solution

Add a lightweight `check` script that uses `jest.ci.config.cjs` (smoke tests only):

```json
"check": "jest --config=jest.ci.config.cjs --runInBand --ci --forceExit"
```

This runs only smoke tests (`feature-flags` and `api-health`) which complete in seconds.

## Impact

- Unblocks PR #1004 and any other PRs affected by this timeout
- No changes to actual test execution (just adds a fast CI-specific script)

## After Merge

PR #1004 (`feature/issue-933-clean`) should rebase on main to get this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new npm script for continuous integration testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->