### PR TITLE
fix(ci): handle race conditions in auto-format workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -48,7 +48,9 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add -A
           git commit -m "style: auto-format code with Prettier [skip ci]"
-          git push
+          # Handle race conditions: pull latest changes before push
+          git pull --rebase origin ${{ github.head_ref }} || true
+          git push || echo "⚠️ Push failed (branch updated) - format changes will be applied on next run"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Quick fix

Adds race condition handling to the auto-format workflow from PR #1010.

### Problem
If multiple commits happen quickly, the auto-format workflow could fail with:
```
! [rejected] branch -> branch (fetch first)
error: failed to push some refs
```

### Solution
Add `git pull --rebase` before push:
```yaml
git pull --rebase origin ${{ github.head_ref }} || true
git push || echo '⚠️ Push failed - will retry on next run'
```

### Changes
- 3 lines added to `.github/workflows/auto-format.yml`

This was meant to be part of #1010 but got merged before this fix was pushed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the auto-format workflow to better handle concurrent push scenarios, reducing potential build failures and improving overall workflow reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->