### PR TITLE
feat(gdpr): GDPR compliance — anonimización, borrado de cuenta, disclaimer IA, páginas legales

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ WORKER_CONCURRENCY=5
 # OAuth — token encryption (min 32 chars, use strong secret in prod)
 TOKEN_ENCRYPTION_KEY=
 
+# GDPR — HMAC key for pseudonymising offender IDs (min 32 chars, use strong secret in prod)
+ANONYMIZE_HMAC_KEY=
+
 # OAuth — YouTube
 YOUTUBE_CLIENT_ID=
 YOUTUBE_CLIENT_SECRET=

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,7 @@ import { IngestionModule } from "./modules/ingestion/ingestion.module";
 import { PersonaModule } from "./modules/persona/persona.module";
 import { FeatureFlagsModule } from "./modules/feature-flags/feature-flags.module";
 import { OAuthModule } from "./modules/oauth/oauth.module";
+import { RoastModule } from "./modules/roast/roast.module";
 import { validateEnv } from "./shared/config/env.validation";
 import { SsotModule } from "./shared/config/ssot.module";
 import { SupabaseAuthGuard } from "./shared/guards/supabase-auth.guard";
@@ -46,6 +47,7 @@ import { SupabaseAuthGuard } from "./shared/guards/supabase-auth.guard";
     PersonaModule,
     FeatureFlagsModule,
     OAuthModule,
+    RoastModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Post,
   Get,
+  Delete,
   Body,
   Req,
   HttpCode,
@@ -127,5 +128,91 @@ export class AuthController {
     }
 
     return { state: body.state };
+  }
+
+  @Delete("account")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteAccount(
+    @Req() req: { user?: { id: string } },
+    @Body() body: { password: string },
+  ): Promise<void> {
+    if (!req.user?.id) {
+      throw new UnauthorizedException();
+    }
+    if (!body.password) {
+      throw new BadRequestException("Password is required");
+    }
+
+    const supabase = createClient(
+      this.config.getOrThrow("SUPABASE_URL"),
+      this.config.getOrThrow("SUPABASE_SERVICE_ROLE_KEY"),
+    );
+
+    // Verify password by attempting sign-in with the user's email
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("email")
+      .eq("id", req.user.id)
+      .maybeSingle();
+
+    if (profileErr || !profile?.email) {
+      throw new InternalServerErrorException("Could not retrieve account");
+    }
+
+    const anonClient = createClient(
+      this.config.getOrThrow("SUPABASE_URL"),
+      this.config.getOrThrow("SUPABASE_ANON_KEY"),
+    );
+    const { error: signInErr } = await anonClient.auth.signInWithPassword({
+      email: profile.email,
+      password: body.password,
+    });
+    if (signInErr) {
+      throw new UnauthorizedException("Invalid password");
+    }
+
+    // Revoke OAuth tokens for all connected accounts
+    const { data: accounts } = await supabase
+      .from("accounts")
+      .select("id, platform, access_token, refresh_token")
+      .eq("user_id", req.user.id);
+
+    if (accounts) {
+      for (const account of accounts) {
+        if (account.access_token) {
+          try {
+            if (account.platform === "youtube") {
+              await fetch(
+                `https://oauth2.googleapis.com/revoke?token=${account.access_token}`,
+                { method: "POST" },
+              );
+            } else if (account.platform === "x") {
+              await fetch("https://api.twitter.com/2/oauth2/revoke", {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: new URLSearchParams({
+                  token: account.access_token,
+                  token_type_hint: "access_token",
+                }),
+              });
+            }
+          } catch {
+            // Best-effort revocation; proceed with deletion regardless
+          }
+        }
+      }
+    }
+
+    // Cascade delete: user data in order of FK dependencies
+    await supabase.from("subscriptions_usage").delete().eq("user_id", req.user.id);
+    await supabase.from("shield_logs").delete().eq("user_id", req.user.id);
+    await supabase.from("offenders").delete().eq("user_id", req.user.id);
+    await supabase.from("accounts").delete().eq("user_id", req.user.id);
+
+    // Delete auth user — triggers cascade on profiles via DB trigger
+    const { error: deleteErr } = await supabase.auth.admin.deleteUser(req.user.id);
+    if (deleteErr) {
+      throw new InternalServerErrorException(deleteErr.message);
+    }
   }
 }

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -134,12 +134,13 @@ export class AuthController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteAccount(
     @Req() req: { user?: { id: string } },
-    @Body() body: { password: string },
+    @Body() body?: { password?: string },
   ): Promise<void> {
     if (!req.user?.id) {
       throw new UnauthorizedException();
     }
-    if (!body.password) {
+    const password = body?.password;
+    if (!password) {
       throw new BadRequestException("Password is required");
     }
 
@@ -165,17 +166,23 @@ export class AuthController {
     );
     const { error: signInErr } = await anonClient.auth.signInWithPassword({
       email: profile.email,
-      password: body.password,
+      password,
     });
     if (signInErr) {
       throw new UnauthorizedException("Invalid password");
     }
 
     // Revoke OAuth tokens for all connected accounts
-    const { data: accounts } = await supabase
+    const { data: accounts, error: accountsErr } = await supabase
       .from("accounts")
       .select("id, platform, access_token, refresh_token")
       .eq("user_id", req.user.id);
+
+    if (accountsErr) {
+      throw new InternalServerErrorException(
+        `Failed to load accounts for revocation: ${accountsErr.message}`,
+      );
+    }
 
     if (accounts) {
       for (const account of accounts) {

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -187,20 +187,17 @@ export class AuthController {
     if (accounts) {
       for (const account of accounts) {
         if (account.access_token) {
+          let revoked = false;
           try {
-            let revoked = false;
             if (account.platform === "youtube") {
-              const res = await fetch(
-                `https://oauth2.googleapis.com/revoke?token=${account.access_token}`,
-                { method: "POST" },
-              );
+              // Send token as form-encoded body (not interpolated into the URL)
+              // so special characters are properly encoded and don't break the request.
+              const res = await fetch("https://oauth2.googleapis.com/revoke", {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: new URLSearchParams({ token: account.access_token }),
+              });
               revoked = res.ok;
-              if (!revoked) {
-                this.logger.warn("YouTube token revocation returned non-ok status", {
-                  accountId: account.id,
-                  status: res.status,
-                });
-              }
             } else if (account.platform === "x") {
               const res = await fetch("https://api.twitter.com/2/oauth2/revoke", {
                 method: "POST",
@@ -211,22 +208,26 @@ export class AuthController {
                 }),
               });
               revoked = res.ok;
-              if (!revoked) {
-                this.logger.warn("X token revocation returned non-ok status", {
-                  accountId: account.id,
-                  status: res.status,
-                });
-              }
+            } else {
+              // Unknown platform — no revocation endpoint; treat as revoked
+              revoked = true;
             }
-            // Account row is deleted below in the cascade; log-only on failure
-            // since the account is being permanently removed.
-            void revoked;
           } catch (err) {
-            this.logger.warn("OAuth token revocation request failed", {
+            this.logger.error("OAuth token revocation request threw", {
               accountId: account.id,
               platform: account.platform,
               error: err instanceof Error ? err.message : String(err),
             });
+          }
+
+          if (!revoked) {
+            // Abort deletion so the token stays in the DB and the user can retry.
+            // Deleting the account row before confirming revocation would
+            // leave the token non-revokable forever.
+            throw new InternalServerErrorException(
+              `OAuth token revocation failed for account ${account.id} (${account.platform}). ` +
+                "Please try again; if the issue persists contact support.",
+            );
           }
         }
       }

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -181,13 +181,21 @@ export class AuthController {
       for (const account of accounts) {
         if (account.access_token) {
           try {
+            let revoked = false;
             if (account.platform === "youtube") {
-              await fetch(
+              const res = await fetch(
                 `https://oauth2.googleapis.com/revoke?token=${account.access_token}`,
                 { method: "POST" },
               );
+              revoked = res.ok;
+              if (!revoked) {
+                this.logger.warn("YouTube token revocation returned non-ok status", {
+                  accountId: account.id,
+                  status: res.status,
+                });
+              }
             } else if (account.platform === "x") {
-              await fetch("https://api.twitter.com/2/oauth2/revoke", {
+              const res = await fetch("https://api.twitter.com/2/oauth2/revoke", {
                 method: "POST",
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: new URLSearchParams({
@@ -195,19 +203,38 @@ export class AuthController {
                   token_type_hint: "access_token",
                 }),
               });
+              revoked = res.ok;
+              if (!revoked) {
+                this.logger.warn("X token revocation returned non-ok status", {
+                  accountId: account.id,
+                  status: res.status,
+                });
+              }
             }
-          } catch {
-            // Best-effort revocation; proceed with deletion regardless
+            // Account row is deleted below in the cascade; log-only on failure
+            // since the account is being permanently removed.
+            void revoked;
+          } catch (err) {
+            this.logger.warn("OAuth token revocation request failed", {
+              accountId: account.id,
+              platform: account.platform,
+              error: err instanceof Error ? err.message : String(err),
+            });
           }
         }
       }
     }
 
     // Cascade delete: user data in order of FK dependencies
-    await supabase.from("subscriptions_usage").delete().eq("user_id", req.user.id);
-    await supabase.from("shield_logs").delete().eq("user_id", req.user.id);
-    await supabase.from("offenders").delete().eq("user_id", req.user.id);
-    await supabase.from("accounts").delete().eq("user_id", req.user.id);
+    const tables = ["subscriptions_usage", "shield_logs", "offenders", "accounts"] as const;
+    for (const table of tables) {
+      const { error: delErr } = await supabase.from(table).delete().eq("user_id", req.user.id);
+      if (delErr) {
+        throw new InternalServerErrorException(
+          `Failed to delete ${table}: ${delErr.message}`,
+        );
+      }
+    }
 
     // Delete auth user — triggers cascade on profiles via DB trigger
     const { error: deleteErr } = await supabase.auth.admin.deleteUser(req.user.id);

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -17,6 +17,22 @@ import { createClient } from "@supabase/supabase-js";
 import { Logger } from "@roastr/shared";
 import { Public } from "../../shared/guards/public.decorator";
 
+const REVOCATION_TIMEOUT_MS = 8_000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 const ONBOARDING_STATES = [
   "welcome",
   "select_plan",
@@ -175,7 +191,7 @@ export class AuthController {
     // Revoke OAuth tokens for all connected accounts
     const { data: accounts, error: accountsErr } = await supabase
       .from("accounts")
-      .select("id, platform, access_token, refresh_token")
+      .select("id, platform, access_token")
       .eq("user_id", req.user.id);
 
     if (accountsErr) {
@@ -190,23 +206,29 @@ export class AuthController {
           let revoked = false;
           try {
             if (account.platform === "youtube") {
-              // Send token as form-encoded body (not interpolated into the URL)
-              // so special characters are properly encoded and don't break the request.
-              const res = await fetch("https://oauth2.googleapis.com/revoke", {
-                method: "POST",
-                headers: { "Content-Type": "application/x-www-form-urlencoded" },
-                body: new URLSearchParams({ token: account.access_token }),
-              });
+              const res = await fetchWithTimeout(
+                "https://oauth2.googleapis.com/revoke",
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                  body: new URLSearchParams({ token: account.access_token }).toString(),
+                },
+                REVOCATION_TIMEOUT_MS,
+              );
               revoked = res.ok;
             } else if (account.platform === "x") {
-              const res = await fetch("https://api.twitter.com/2/oauth2/revoke", {
-                method: "POST",
-                headers: { "Content-Type": "application/x-www-form-urlencoded" },
-                body: new URLSearchParams({
-                  token: account.access_token,
-                  token_type_hint: "access_token",
-                }),
-              });
+              const res = await fetchWithTimeout(
+                "https://api.twitter.com/2/oauth2/revoke",
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                  body: new URLSearchParams({
+                    token: account.access_token,
+                    token_type_hint: "access_token",
+                  }).toString(),
+                },
+                REVOCATION_TIMEOUT_MS,
+              );
               revoked = res.ok;
             } else {
               // Unknown platform — no revocation endpoint; treat as revoked

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -159,6 +159,9 @@ export class AuthController {
     if (!password) {
       throw new BadRequestException("Password is required");
     }
+    if (typeof password !== "string") {
+      throw new BadRequestException("Password must be a string");
+    }
 
     const supabase = createClient(
       this.config.getOrThrow("SUPABASE_URL"),
@@ -231,8 +234,12 @@ export class AuthController {
               );
               revoked = res.ok;
             } else {
-              // Unknown platform — no revocation endpoint; treat as revoked
-              revoked = true;
+              // Unknown platform — fail closed: leave revoked = false so the
+              // deletion is aborted below. Log for manual review.
+              this.logger.error("Cannot revoke token for unknown platform", {
+                accountId: account.id,
+                platform: account.platform,
+              });
             }
           } catch (err) {
             this.logger.error("OAuth token revocation request threw", {

--- a/apps/api/src/modules/roast/disclaimer.service.ts
+++ b/apps/api/src/modules/roast/disclaimer.service.ts
@@ -19,6 +19,9 @@ const DISCLAIMER_DEFAULT =
 @Injectable()
 export class DisclaimerService {
   apply(content: string, platform: Platform): string {
+    if (this.hasDisclaimer(content, platform)) {
+      return content;
+    }
     switch (platform.toLowerCase()) {
       case "youtube":
         return content + DISCLAIMER_YOUTUBE;

--- a/apps/api/src/modules/roast/disclaimer.service.ts
+++ b/apps/api/src/modules/roast/disclaimer.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from "@nestjs/common";
+
+export type Platform = "youtube" | "x" | string;
+
+const DISCLAIMER_YOUTUBE =
+  "\n\n⚠️ Este comentario fue generado con asistencia de IA (Roastr). No representa la opinión personal del creador.";
+
+const DISCLAIMER_X_PREFIX = "[AI] ";
+
+const DISCLAIMER_DEFAULT =
+  " [Generado con IA — Roastr]";
+
+/**
+ * Adds platform-appropriate AI disclaimers to roast content.
+ * - YouTube: appended footer text
+ * - X (Twitter): [AI] prefix (space-aware)
+ * - Other: inline suffix
+ */
+@Injectable()
+export class DisclaimerService {
+  apply(content: string, platform: Platform): string {
+    switch (platform.toLowerCase()) {
+      case "youtube":
+        return content + DISCLAIMER_YOUTUBE;
+      case "x":
+      case "twitter":
+        return DISCLAIMER_X_PREFIX + content;
+      default:
+        return content + DISCLAIMER_DEFAULT;
+    }
+  }
+
+  /**
+   * Returns true if the content already has a disclaimer applied.
+   */
+  hasDisclaimer(content: string, platform: Platform): boolean {
+    switch (platform.toLowerCase()) {
+      case "youtube":
+        return content.includes(DISCLAIMER_YOUTUBE);
+      case "x":
+      case "twitter":
+        return content.startsWith(DISCLAIMER_X_PREFIX);
+      default:
+        return content.includes(DISCLAIMER_DEFAULT);
+    }
+  }
+}

--- a/apps/api/src/modules/roast/roast.module.ts
+++ b/apps/api/src/modules/roast/roast.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { DisclaimerService } from "./disclaimer.service";
+
+@Module({
+  providers: [DisclaimerService],
+  exports: [DisclaimerService],
+})
+export class RoastModule {}

--- a/apps/api/src/modules/shield/anonymize.service.ts
+++ b/apps/api/src/modules/shield/anonymize.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { createClient } from "@supabase/supabase-js";
+import { createHash } from "crypto";
+
+const ANON_PREFIX = "anon:";
+
+export function hashIdentifier(raw: string): string {
+  return ANON_PREFIX + createHash("sha256").update(raw).digest("hex").slice(0, 16);
+}
+
+export function isAnonymized(value: string): boolean {
+  return value.startsWith(ANON_PREFIX);
+}
+
+@Injectable()
+export class AnonymizeService {
+  constructor(private readonly config: ConfigService) {}
+
+  private getSupabase() {
+    return createClient(
+      this.config.getOrThrow("SUPABASE_URL"),
+      this.config.getOrThrow("SUPABASE_SERVICE_ROLE_KEY"),
+    );
+  }
+
+  /**
+   * Anonymizes PII in offender records older than cutoff.
+   * Replaces offender_id with a deterministic SHA-256 hash while preserving strike stats.
+   * Skips records already anonymized.
+   */
+  async anonymizeOldOffenders(cutoffIso: string): Promise<{ anonymized: number }> {
+    const supabase = this.getSupabase();
+
+    const { data: candidates, error: fetchErr } = await supabase
+      .from("offenders")
+      .select("id, offender_id, last_strike, created_at")
+      .or(`last_strike.is.null,last_strike.lt.${cutoffIso}`)
+      .lt("created_at", cutoffIso);
+
+    if (fetchErr) throw fetchErr;
+    if (!candidates || candidates.length === 0) return { anonymized: 0 };
+
+    const toAnonymize = (candidates as { id: string; offender_id: string }[]).filter(
+      (r) => !isAnonymized(r.offender_id),
+    );
+    if (toAnonymize.length === 0) return { anonymized: 0 };
+
+    const updates = toAnonymize.map(({ id, offender_id }) => ({
+      id,
+      offender_id: hashIdentifier(offender_id),
+      updated_at: new Date().toISOString(),
+    }));
+
+    const { error: updateErr } = await supabase
+      .from("offenders")
+      .upsert(updates, { onConflict: "id" });
+
+    if (updateErr) throw updateErr;
+
+    return { anonymized: toAnonymize.length };
+  }
+}

--- a/apps/api/src/modules/shield/anonymize.service.ts
+++ b/apps/api/src/modules/shield/anonymize.service.ts
@@ -1,17 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { createClient } from "@supabase/supabase-js";
-import { createHash } from "crypto";
-
-const ANON_PREFIX = "anon:";
-
-export function hashIdentifier(raw: string): string {
-  return ANON_PREFIX + createHash("sha256").update(raw).digest("hex").slice(0, 16);
-}
-
-export function isAnonymized(value: string): boolean {
-  return value.startsWith(ANON_PREFIX);
-}
+import { hashIdentifier, isAnonymized } from "@roastr/shared";
 
 @Injectable()
 export class AnonymizeService {
@@ -24,9 +14,13 @@ export class AnonymizeService {
     );
   }
 
+  private get hmacKey(): string {
+    return this.config.getOrThrow("ANONYMIZE_HMAC_KEY");
+  }
+
   /**
    * Anonymizes PII in offender records older than cutoff.
-   * Replaces offender_id with a deterministic SHA-256 hash while preserving strike stats.
+   * Replaces offender_id with a keyed HMAC-SHA256 digest while preserving strike stats.
    * Skips records already anonymized.
    */
   async anonymizeOldOffenders(cutoffIso: string): Promise<{ anonymized: number }> {
@@ -46,9 +40,10 @@ export class AnonymizeService {
     );
     if (toAnonymize.length === 0) return { anonymized: 0 };
 
+    const secret = this.hmacKey;
     const updates = toAnonymize.map(({ id, offender_id }) => ({
       id,
-      offender_id: hashIdentifier(offender_id),
+      offender_id: hashIdentifier(offender_id, secret),
       updated_at: new Date().toISOString(),
     }));
 

--- a/apps/api/src/modules/shield/shield.module.ts
+++ b/apps/api/src/modules/shield/shield.module.ts
@@ -4,12 +4,13 @@ import { ShieldController } from "./shield.controller";
 import { ShieldConfigService } from "./shield-config.service";
 import { ShieldLogsService } from "./shield-logs.service";
 import { OffendersService } from "./offenders.service";
+import { AnonymizeService } from "./anonymize.service";
 import { SubscriptionGuard } from "../../shared/guards/subscription.guard";
 
 @Module({
   imports: [ConfigModule],
   controllers: [ShieldController],
-  providers: [ShieldConfigService, ShieldLogsService, OffendersService, SubscriptionGuard],
-  exports: [ShieldConfigService, OffendersService],
+  providers: [ShieldConfigService, ShieldLogsService, OffendersService, AnonymizeService, SubscriptionGuard],
+  exports: [ShieldConfigService, OffendersService, AnonymizeService],
 })
 export class ShieldModule {}

--- a/apps/api/test/auth/account-deletion.spec.ts
+++ b/apps/api/test/auth/account-deletion.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  UnauthorizedException,
+  BadRequestException,
+  InternalServerErrorException,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { AuthController } from "../../src/modules/auth/auth.controller";
+
+// ─── Supabase mock factory ───────────────────────────────────────────────────
+
+type MockChain = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  not: ReturnType<typeof vi.fn>;
+  lt: ReturnType<typeof vi.fn>;
+  _resolve: (result: { data: unknown; error: unknown }) => void;
+};
+
+function makeChain(defaultResult = { data: null, error: null }): MockChain {
+  const chain: MockChain = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    delete: vi.fn(),
+    maybeSingle: vi.fn(),
+    not: vi.fn(),
+    lt: vi.fn(),
+    _resolve: () => {},
+  };
+
+  const self = () => Promise.resolve(defaultResult);
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.delete.mockReturnValue(chain);
+  chain.not.mockReturnValue(chain);
+  chain.lt.mockReturnValue(chain);
+  chain.maybeSingle.mockImplementation(self);
+
+  return chain;
+}
+
+const adminDeleteUser = vi.fn();
+const signInWithPassword = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn((_url: string, key: string) => {
+    // Service role key → admin client; anon key → anon client
+    if (key === "service-key") {
+      return {
+        from: mockFrom,
+        auth: {
+          admin: { deleteUser: adminDeleteUser },
+        },
+      };
+    }
+    return {
+      from: mockFrom,
+      auth: {
+        signInWithPassword,
+      },
+    };
+  }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Record<string, string> = {}): ConfigService {
+  const defaults: Record<string, string> = {
+    SUPABASE_URL: "https://test.supabase.co",
+    SUPABASE_SERVICE_ROLE_KEY: "service-key",
+    SUPABASE_ANON_KEY: "anon-key",
+  };
+  return {
+    getOrThrow: vi.fn((key: string) => overrides[key] ?? defaults[key] ?? ""),
+  } as unknown as ConfigService;
+}
+
+function makeReq(userId = "user-123") {
+  return { user: { id: userId } };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("AuthController.deleteAccount", () => {
+  let controller: AuthController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new AuthController(makeConfig());
+  });
+
+  it("throws 401 when no authenticated user", async () => {
+    await expect(
+      controller.deleteAccount({ user: undefined }, { password: "pw" }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it("throws 400 when password is missing", async () => {
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "" }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it("throws 401 when password verification fails", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    mockFrom.mockReturnValue(profileChain);
+    signInWithPassword.mockResolvedValue({ error: { message: "Invalid credentials" } });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "wrong" }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it("throws 500 when profile lookup fails", async () => {
+    const profileChain = makeChain({ data: null, error: { message: "db error" } });
+    mockFrom.mockReturnValue(profileChain);
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "pw" }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it("throws 500 when auth.admin.deleteUser fails after successful deletion cascade", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    mockFrom.mockReturnValue(profileChain);
+    signInWithPassword.mockResolvedValue({ error: null });
+    adminDeleteUser.mockResolvedValue({ error: { message: "delete failed" } });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "correct" }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it("completes deletion cascade and returns 204", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    const accountsChain = makeChain({ data: [], error: null });
+    mockFrom
+      .mockReturnValueOnce(profileChain)   // profiles lookup
+      .mockReturnValue(accountsChain);      // all cascade deletes
+    signInWithPassword.mockResolvedValue({ error: null });
+    adminDeleteUser.mockResolvedValue({ error: null });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "correct" }),
+    ).resolves.toBeUndefined();
+
+    expect(adminDeleteUser).toHaveBeenCalledWith("user-123");
+  });
+});

--- a/apps/api/test/auth/account-deletion.spec.ts
+++ b/apps/api/test/auth/account-deletion.spec.ts
@@ -16,27 +16,27 @@ type MockChain = {
   maybeSingle: ReturnType<typeof vi.fn>;
   not: ReturnType<typeof vi.fn>;
   lt: ReturnType<typeof vi.fn>;
+  then: (
+    onFulfilled: (v: { data: unknown; error: unknown }) => unknown,
+    onRejected?: (e: unknown) => unknown,
+  ) => Promise<unknown>;
   _resolve: (result: { data: unknown; error: unknown }) => void;
 };
 
 function makeChain(defaultResult = { data: null, error: null }): MockChain {
-  const chain: MockChain = {
-    select: vi.fn(),
-    eq: vi.fn(),
-    delete: vi.fn(),
-    maybeSingle: vi.fn(),
-    not: vi.fn(),
-    lt: vi.fn(),
-    _resolve: () => {},
-  };
+  const chain = {} as MockChain;
 
-  const self = () => Promise.resolve(defaultResult);
-  chain.select.mockReturnValue(chain);
-  chain.eq.mockReturnValue(chain);
-  chain.delete.mockReturnValue(chain);
-  chain.not.mockReturnValue(chain);
-  chain.lt.mockReturnValue(chain);
-  chain.maybeSingle.mockImplementation(self);
+  // Make the chain itself thenable so `await chain` resolves to defaultResult
+  chain.then = (onFulfilled, onRejected) =>
+    Promise.resolve(defaultResult).then(onFulfilled, onRejected);
+
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.delete = vi.fn().mockReturnValue(chain);
+  chain.not = vi.fn().mockReturnValue(chain);
+  chain.lt = vi.fn().mockReturnValue(chain);
+  chain.maybeSingle = vi.fn().mockImplementation(() => Promise.resolve(defaultResult));
+  chain._resolve = () => {};
 
   return chain;
 }
@@ -123,6 +123,21 @@ describe("AuthController.deleteAccount", () => {
     ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
+  it("throws 500 when a cascade delete fails", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    const accountsChain = makeChain({ data: [], error: null });
+    const failChain = makeChain({ data: null, error: { message: "constraint violation" } });
+    mockFrom
+      .mockReturnValueOnce(profileChain)  // profiles lookup
+      .mockReturnValueOnce(accountsChain) // accounts select (OAuth revocation fetch)
+      .mockReturnValueOnce(failChain);    // first cascade delete fails
+    signInWithPassword.mockResolvedValue({ error: null });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "correct" }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
   it("throws 500 when auth.admin.deleteUser fails after successful deletion cascade", async () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
     mockFrom.mockReturnValue(profileChain);
@@ -139,7 +154,7 @@ describe("AuthController.deleteAccount", () => {
     const accountsChain = makeChain({ data: [], error: null });
     mockFrom
       .mockReturnValueOnce(profileChain)   // profiles lookup
-      .mockReturnValue(accountsChain);      // all cascade deletes
+      .mockReturnValue(accountsChain);      // accounts select + all cascade deletes
     signInWithPassword.mockResolvedValue({ error: null });
     adminDeleteUser.mockResolvedValue({ error: null });
 

--- a/apps/api/test/auth/account-deletion.spec.ts
+++ b/apps/api/test/auth/account-deletion.spec.ts
@@ -9,32 +9,36 @@ import { AuthController } from "../../src/modules/auth/auth.controller";
 
 // ─── Supabase mock factory ───────────────────────────────────────────────────
 
-type MockChain = {
+type MockMethods = {
   select: ReturnType<typeof vi.fn>;
   eq: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
   maybeSingle: ReturnType<typeof vi.fn>;
   not: ReturnType<typeof vi.fn>;
   lt: ReturnType<typeof vi.fn>;
-  then: (
-    onFulfilled: (v: { data: unknown; error: unknown }) => unknown,
-    onRejected?: (e: unknown) => unknown,
-  ) => Promise<unknown>;
+  gt: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
   _resolve: (result: { data: unknown; error: unknown }) => void;
 };
 
-function makeChain(defaultResult = { data: null, error: null }): MockChain {
-  const chain = {} as MockChain;
+type MockChain = Promise<{ data: unknown; error: unknown }> & MockMethods;
 
-  // Make the chain itself thenable so `await chain` resolves to defaultResult
-  chain.then = (onFulfilled, onRejected) =>
-    Promise.resolve(defaultResult).then(onFulfilled, onRejected);
+function makeChain(defaultResult = { data: null as unknown, error: null as unknown }): MockChain {
+  // Start from a real Promise so the chain is a true thenable — no manual
+  // `.then` property needed, which avoids lint/noThenProperty violations.
+  const chain = Promise.resolve(defaultResult) as unknown as MockChain;
 
   chain.select = vi.fn().mockReturnValue(chain);
   chain.eq = vi.fn().mockReturnValue(chain);
   chain.delete = vi.fn().mockReturnValue(chain);
   chain.not = vi.fn().mockReturnValue(chain);
   chain.lt = vi.fn().mockReturnValue(chain);
+  chain.gt = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockReturnValue(chain);
+  chain.or = vi.fn().mockReturnValue(chain);
   chain.maybeSingle = vi.fn().mockImplementation(() => Promise.resolve(defaultResult));
   chain._resolve = () => {};
 
@@ -94,11 +98,17 @@ describe("AuthController.deleteAccount", () => {
 
   it("throws 401 when no authenticated user", async () => {
     await expect(
-      controller.deleteAccount({ user: undefined }, { password: "pw" }),
+      controller.deleteAccount({ user: undefined }, undefined),
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
-  it("throws 400 when password is missing", async () => {
+  it("throws 400 when body is missing", async () => {
+    await expect(
+      controller.deleteAccount(makeReq(), undefined),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it("throws 400 when password is empty", async () => {
     await expect(
       controller.deleteAccount(makeReq(), { password: "" }),
     ).rejects.toBeInstanceOf(BadRequestException);
@@ -123,14 +133,27 @@ describe("AuthController.deleteAccount", () => {
     ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
+  it("throws 500 when accounts query fails before revocation", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    const accountsErrorChain = makeChain({ data: null, error: { message: "network error" } });
+    mockFrom
+      .mockReturnValueOnce(profileChain)     // profiles lookup
+      .mockReturnValueOnce(accountsErrorChain); // accounts select fails
+    signInWithPassword.mockResolvedValue({ error: null });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "correct" }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
   it("throws 500 when a cascade delete fails", async () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
     const accountsChain = makeChain({ data: [], error: null });
     const failChain = makeChain({ data: null, error: { message: "constraint violation" } });
     mockFrom
-      .mockReturnValueOnce(profileChain)  // profiles lookup
-      .mockReturnValueOnce(accountsChain) // accounts select (OAuth revocation fetch)
-      .mockReturnValueOnce(failChain);    // first cascade delete fails
+      .mockReturnValueOnce(profileChain)   // profiles lookup
+      .mockReturnValueOnce(accountsChain)  // accounts select (OAuth revocation)
+      .mockReturnValueOnce(failChain);     // first cascade delete fails
     signInWithPassword.mockResolvedValue({ error: null });
 
     await expect(
@@ -140,7 +163,11 @@ describe("AuthController.deleteAccount", () => {
 
   it("throws 500 when auth.admin.deleteUser fails after successful deletion cascade", async () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
-    mockFrom.mockReturnValue(profileChain);
+    const accountsChain = makeChain({ data: [], error: null });
+    mockFrom
+      .mockReturnValueOnce(profileChain)   // profiles lookup
+      .mockReturnValueOnce(accountsChain)  // accounts select (OAuth revocation)
+      .mockReturnValue(accountsChain);     // all cascade deletes succeed
     signInWithPassword.mockResolvedValue({ error: null });
     adminDeleteUser.mockResolvedValue({ error: { message: "delete failed" } });
 
@@ -154,7 +181,8 @@ describe("AuthController.deleteAccount", () => {
     const accountsChain = makeChain({ data: [], error: null });
     mockFrom
       .mockReturnValueOnce(profileChain)   // profiles lookup
-      .mockReturnValue(accountsChain);      // accounts select + all cascade deletes
+      .mockReturnValueOnce(accountsChain)  // accounts select (OAuth revocation)
+      .mockReturnValue(accountsChain);     // all cascade deletes
     signInWithPassword.mockResolvedValue({ error: null });
     adminDeleteUser.mockResolvedValue({ error: null });
 

--- a/apps/api/test/auth/account-deletion.spec.ts
+++ b/apps/api/test/auth/account-deletion.spec.ts
@@ -155,7 +155,7 @@ describe("AuthController.deleteAccount", () => {
   it("throws 500 when OAuth token revocation fails (non-ok response)", async () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
     const accountsChain = makeChain({
-      data: [{ id: "acc-1", platform: "youtube", access_token: "tok", refresh_token: null }],
+      data: [{ id: "acc-1", platform: "youtube", access_token: "tok" }],
       error: null,
     });
     mockFrom
@@ -222,7 +222,7 @@ describe("AuthController.deleteAccount", () => {
   it("completes deletion cascade with successful YouTube token revocation", async () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
     const accountsChain = makeChain({
-      data: [{ id: "acc-1", platform: "youtube", access_token: "yt-tok", refresh_token: null }],
+      data: [{ id: "acc-1", platform: "youtube", access_token: "yt-tok" }],
       error: null,
     });
     const okChain = makeChain({ data: [], error: null });
@@ -238,10 +238,14 @@ describe("AuthController.deleteAccount", () => {
       controller.deleteAccount(makeReq(), { password: "correct" }),
     ).resolves.toBeUndefined();
 
-    // Google revocation must use form-encoded body, not query param interpolation
+    // Google revocation must be a form-encoded POST (not raw URL interpolation)
     expect(mockFetch).toHaveBeenCalledWith(
       "https://oauth2.googleapis.com/revoke",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ token: "yt-tok" }).toString(),
+      }),
     );
     expect(adminDeleteUser).toHaveBeenCalledWith("user-123");
   });

--- a/apps/api/test/auth/account-deletion.spec.ts
+++ b/apps/api/test/auth/account-deletion.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   UnauthorizedException,
   BadRequestException,
@@ -7,9 +7,9 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { AuthController } from "../../src/modules/auth/auth.controller";
 
-// Global fetch mock — replaced per-test as needed
+// Declared at module scope for stable reference across tests;
+// installed/torn-down per test via beforeEach/afterEach for proper isolation.
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 // ─── Supabase mock factory ───────────────────────────────────────────────────
 
@@ -97,9 +97,14 @@ describe("AuthController.deleteAccount", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
     // Default: fetch succeeds (revocation ok)
     mockFetch.mockResolvedValue({ ok: true, status: 200 });
     controller = new AuthController(makeConfig());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("throws 401 when no authenticated user", async () => {

--- a/apps/api/test/auth/account-deletion.spec.ts
+++ b/apps/api/test/auth/account-deletion.spec.ts
@@ -7,6 +7,10 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { AuthController } from "../../src/modules/auth/auth.controller";
 
+// Global fetch mock — replaced per-test as needed
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
 // ─── Supabase mock factory ───────────────────────────────────────────────────
 
 type MockMethods = {
@@ -93,6 +97,8 @@ describe("AuthController.deleteAccount", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: fetch succeeds (revocation ok)
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
     controller = new AuthController(makeConfig());
   });
 
@@ -137,7 +143,7 @@ describe("AuthController.deleteAccount", () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
     const accountsErrorChain = makeChain({ data: null, error: { message: "network error" } });
     mockFrom
-      .mockReturnValueOnce(profileChain)     // profiles lookup
+      .mockReturnValueOnce(profileChain)       // profiles lookup
       .mockReturnValueOnce(accountsErrorChain); // accounts select fails
     signInWithPassword.mockResolvedValue({ error: null });
 
@@ -146,13 +152,33 @@ describe("AuthController.deleteAccount", () => {
     ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
+  it("throws 500 when OAuth token revocation fails (non-ok response)", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    const accountsChain = makeChain({
+      data: [{ id: "acc-1", platform: "youtube", access_token: "tok", refresh_token: null }],
+      error: null,
+    });
+    mockFrom
+      .mockReturnValueOnce(profileChain)  // profiles lookup
+      .mockReturnValueOnce(accountsChain); // accounts select
+    signInWithPassword.mockResolvedValue({ error: null });
+    mockFetch.mockResolvedValue({ ok: false, status: 400 });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "correct" }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+
+    // Cascade delete must NOT have been called — account data is preserved for retry
+    expect(adminDeleteUser).not.toHaveBeenCalled();
+  });
+
   it("throws 500 when a cascade delete fails", async () => {
     const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
     const accountsChain = makeChain({ data: [], error: null });
     const failChain = makeChain({ data: null, error: { message: "constraint violation" } });
     mockFrom
       .mockReturnValueOnce(profileChain)   // profiles lookup
-      .mockReturnValueOnce(accountsChain)  // accounts select (OAuth revocation)
+      .mockReturnValueOnce(accountsChain)  // accounts select (no tokens to revoke)
       .mockReturnValueOnce(failChain);     // first cascade delete fails
     signInWithPassword.mockResolvedValue({ error: null });
 
@@ -166,7 +192,7 @@ describe("AuthController.deleteAccount", () => {
     const accountsChain = makeChain({ data: [], error: null });
     mockFrom
       .mockReturnValueOnce(profileChain)   // profiles lookup
-      .mockReturnValueOnce(accountsChain)  // accounts select (OAuth revocation)
+      .mockReturnValueOnce(accountsChain)  // accounts select (no tokens to revoke)
       .mockReturnValue(accountsChain);     // all cascade deletes succeed
     signInWithPassword.mockResolvedValue({ error: null });
     adminDeleteUser.mockResolvedValue({ error: { message: "delete failed" } });
@@ -181,7 +207,7 @@ describe("AuthController.deleteAccount", () => {
     const accountsChain = makeChain({ data: [], error: null });
     mockFrom
       .mockReturnValueOnce(profileChain)   // profiles lookup
-      .mockReturnValueOnce(accountsChain)  // accounts select (OAuth revocation)
+      .mockReturnValueOnce(accountsChain)  // accounts select (no tokens to revoke)
       .mockReturnValue(accountsChain);     // all cascade deletes
     signInWithPassword.mockResolvedValue({ error: null });
     adminDeleteUser.mockResolvedValue({ error: null });
@@ -190,6 +216,33 @@ describe("AuthController.deleteAccount", () => {
       controller.deleteAccount(makeReq(), { password: "correct" }),
     ).resolves.toBeUndefined();
 
+    expect(adminDeleteUser).toHaveBeenCalledWith("user-123");
+  });
+
+  it("completes deletion cascade with successful YouTube token revocation", async () => {
+    const profileChain = makeChain({ data: { email: "user@test.com" }, error: null });
+    const accountsChain = makeChain({
+      data: [{ id: "acc-1", platform: "youtube", access_token: "yt-tok", refresh_token: null }],
+      error: null,
+    });
+    const okChain = makeChain({ data: [], error: null });
+    mockFrom
+      .mockReturnValueOnce(profileChain)   // profiles lookup
+      .mockReturnValueOnce(accountsChain)  // accounts select
+      .mockReturnValue(okChain);           // all cascade deletes
+    signInWithPassword.mockResolvedValue({ error: null });
+    adminDeleteUser.mockResolvedValue({ error: null });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await expect(
+      controller.deleteAccount(makeReq(), { password: "correct" }),
+    ).resolves.toBeUndefined();
+
+    // Google revocation must use form-encoded body, not query param interpolation
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/revoke",
+      expect.objectContaining({ method: "POST" }),
+    );
     expect(adminDeleteUser).toHaveBeenCalledWith("user-123");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,8 @@ import { DashboardPage } from "./routes/dashboard";
 import { SettingsPage } from "./routes/settings";
 import { OnboardingWizard } from "./components/onboarding/OnboardingWizard";
 import { BillingRoute } from "./routes/billing";
+import { PrivacyPage } from "./routes/privacy";
+import { TermsPage } from "./routes/terms";
 
 export function App() {
   return (
@@ -23,6 +25,8 @@ export function App() {
           <Route path="/connect" element={<ProtectedRoute><ConnectPage /></ProtectedRoute>} />
           <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
           <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+          <Route path="/privacy" element={<PrivacyPage />} />
+          <Route path="/terms" element={<TermsPage />} />
           <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
       </BrowserRouter>

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -1,0 +1,67 @@
+export function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="mb-2 text-3xl font-bold text-foreground">Privacy Policy</h1>
+        <p className="mb-8 text-sm text-muted-foreground">Última actualización: marzo 2026</p>
+
+        <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8 text-foreground">
+          <section>
+            <h2 className="text-xl font-semibold">1. Datos que recopilamos</h2>
+            <p className="mt-2 text-muted-foreground">
+              Roastr recopila únicamente los datos necesarios para prestar el servicio: dirección de
+              correo electrónico, credenciales de acceso OAuth a plataformas conectadas y registros de
+              actividad del Shield (sin almacenar el texto de comentarios individuales).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">2. Uso de los datos</h2>
+            <p className="mt-2 text-muted-foreground">
+              Los datos se usan exclusivamente para operar y mejorar el servicio. No vendemos ni
+              compartimos información personal con terceros salvo obligación legal.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">3. Retención de datos</h2>
+            <p className="mt-2 text-muted-foreground">
+              Los registros de actividad del Shield y los candidatos a roast se eliminan automáticamente
+              transcurridos 90 días. Los registros de infractores se anonimizan (el identificador se
+              reemplaza por un hash irreversible) conservando únicamente las estadísticas agregadas.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">4. Tus derechos (GDPR)</h2>
+            <p className="mt-2 text-muted-foreground">
+              Tienes derecho de acceso, rectificación, portabilidad y supresión de tus datos. Puedes
+              eliminar tu cuenta en cualquier momento desde{" "}
+              <strong>Ajustes → Cuenta → Eliminar cuenta</strong>. Todos tus datos personales se
+              borrarán de forma permanente e irreversible.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">5. Seguridad</h2>
+            <p className="mt-2 text-muted-foreground">
+              Los tokens OAuth se almacenan cifrados. Utilizamos Supabase con Row Level Security para
+              garantizar que cada usuario solo accede a sus propios datos.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">6. Contacto</h2>
+            <p className="mt-2 text-muted-foreground">
+              Para cualquier consulta sobre privacidad escríbenos a{" "}
+              <a href="mailto:privacy@roastr.ai" className="text-primary underline">
+                privacy@roastr.ai
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -57,6 +57,10 @@ export function PrivacyPage() {
               <a href="mailto:privacy@roastr.ai" className="text-primary underline">
                 privacy@roastr.ai
               </a>
+              . Consulta también nuestros{" "}
+              <a href="/terms" target="_blank" rel="noreferrer" className="text-primary underline">
+                Términos de Servicio
+              </a>
               .
             </p>
           </section>

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -1,0 +1,74 @@
+export function TermsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="mb-2 text-3xl font-bold text-foreground">Terms of Service</h1>
+        <p className="mb-8 text-sm text-muted-foreground">Última actualización: marzo 2026</p>
+
+        <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8 text-foreground">
+          <section>
+            <h2 className="text-xl font-semibold">1. Aceptación</h2>
+            <p className="mt-2 text-muted-foreground">
+              Al utilizar Roastr aceptas estos términos. Si no estás de acuerdo, no uses el servicio.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">2. Descripción del servicio</h2>
+            <p className="mt-2 text-muted-foreground">
+              Roastr es una herramienta de moderación y respuesta automática para creadores de
+              contenido. Utiliza inteligencia artificial para analizar comentarios y generar respuestas.
+              Toda respuesta generada por IA es claramente identificada como tal.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">3. Uso aceptable</h2>
+            <p className="mt-2 text-muted-foreground">
+              No puedes usar Roastr para acosar, difamar, discriminar ni para actividades ilegales.
+              Eres responsable del uso que haces de las respuestas generadas antes de publicarlas.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">4. Divulgación de IA</h2>
+            <p className="mt-2 text-muted-foreground">
+              Todas las respuestas publicadas a través de Roastr incluyen una indicación visible de
+              que han sido generadas con asistencia de IA, cumpliendo con los términos de servicio de
+              las plataformas conectadas.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">5. Suscripciones y pagos</h2>
+            <p className="mt-2 text-muted-foreground">
+              Los planes de pago se facturan mensualmente a través de Polar. Puedes cancelar en
+              cualquier momento. No se realizan reembolsos por períodos parciales salvo obligación
+              legal.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">6. Limitación de responsabilidad</h2>
+            <p className="mt-2 text-muted-foreground">
+              Roastr se proporciona "tal cual". No garantizamos la exactitud de las respuestas
+              generadas por IA. No somos responsables de las consecuencias de publicar contenido
+              generado sin revisión previa.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold">7. Contacto</h2>
+            <p className="mt-2 text-muted-foreground">
+              Para consultas legales escríbenos a{" "}
+              <a href="mailto:legal@roastr.ai" className="text-primary underline">
+                legal@roastr.ai
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -64,6 +64,10 @@ export function TermsPage() {
               <a href="mailto:legal@roastr.ai" className="text-primary underline">
                 legal@roastr.ai
               </a>
+              . Consulta también nuestra{" "}
+              <a href="/privacy" target="_blank" rel="noreferrer" className="text-primary underline">
+                Política de Privacidad
+              </a>
               .
             </p>
           </section>

--- a/apps/worker/src/processors/maintenance.ts
+++ b/apps/worker/src/processors/maintenance.ts
@@ -66,31 +66,46 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
     }
     roastCandidatesDeleted = roastData?.length ?? 0;
 
-    // 3. Anonymize old offenders — preserve strike_count, hash PII (offender_id)
-    const { data: candidates, error: fetchErr } = await supabase
-      .from("offenders")
-      .select("id, offender_id, last_strike, created_at")
-      .or(`last_strike.is.null,last_strike.lt.${cutoffIso}`)
-      .lt("created_at", cutoffIso);
+    // 3. Anonymize old offenders in pages to avoid memory/payload limits.
+    //    Cursor-paginate by created_at ascending; stop when a page is empty.
+    const PAGE_SIZE = 500;
+    let cursor = "1970-01-01T00:00:00.000Z";
 
-    if (fetchErr) throw fetchErr;
+    for (;;) {
+      const { data: page, error: pageErr } = await supabase
+        .from("offenders")
+        .select("id, offender_id, created_at")
+        .or(`last_strike.is.null,last_strike.lt.${cutoffIso}`)
+        .lt("created_at", cutoffIso)
+        .gt("created_at", cursor)
+        .order("created_at", { ascending: true })
+        .limit(PAGE_SIZE);
 
-    if (candidates && candidates.length > 0) {
-      const toAnonymize = (candidates as { id: string; offender_id: string }[]).filter(
-        (r) => !isAnonymized(r.offender_id),
-      );
+      if (pageErr) throw pageErr;
+      if (!page || page.length === 0) break;
+
+      const toAnonymize = (page as { id: string; offender_id: string; created_at: string }[])
+        .filter((r) => !isAnonymized(r.offender_id));
+
       if (toAnonymize.length > 0) {
+        const now = new Date().toISOString();
         const updates = toAnonymize.map(({ id, offender_id }) => ({
           id,
           offender_id: hashIdentifier(offender_id, anonymizeSecret),
-          updated_at: new Date().toISOString(),
+          updated_at: now,
         }));
         const { error: updateErr } = await supabase
           .from("offenders")
           .upsert(updates, { onConflict: "id" });
         if (updateErr) throw updateErr;
-        offendersAnonymized = toAnonymize.length;
+        offendersAnonymized += toAnonymize.length;
       }
+
+      // Advance cursor to the last row's created_at so next page starts after it
+      cursor = (page[page.length - 1] as { created_at: string }).created_at;
+
+      // If we got fewer rows than the page size we've exhausted all results
+      if (page.length < PAGE_SIZE) break;
     }
 
     // 4. Purge accounts flagged for retention expiry

--- a/apps/worker/src/processors/maintenance.ts
+++ b/apps/worker/src/processors/maintenance.ts
@@ -1,8 +1,18 @@
 import type { Job } from "bullmq";
 import { createClient } from "@supabase/supabase-js";
+import { createHash } from "crypto";
 import { createJobLogger } from "../shared/logger.js";
 
 const RETENTION_DAYS = 90;
+const ANON_PREFIX = "anon:";
+
+function hashIdentifier(raw: string): string {
+  return ANON_PREFIX + createHash("sha256").update(raw).digest("hex").slice(0, 16);
+}
+
+function isAnonymized(value: string): boolean {
+  return value.startsWith(ANON_PREFIX);
+}
 
 export async function maintenanceProcessor(job: Job): Promise<void> {
   const log = createJobLogger("maintenance", job.id ?? "unknown");
@@ -29,10 +39,12 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
   const cutoffIso = cutoff.toISOString();
 
   let shieldLogsDeleted = 0;
-  let offendersDeleted = 0;
+  let roastCandidatesDeleted = 0;
+  let offendersAnonymized = 0;
   let accountsPurged = 0;
 
   try {
+    // 1. Delete shield_logs older than 90 days
     const { data: shieldData, error: shieldErr } = await supabase
       .from("shield_logs")
       .delete()
@@ -45,30 +57,47 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
     }
     shieldLogsDeleted = shieldData?.length ?? 0;
 
-    const { data: offendersNull, error: err1 } = await supabase
-      .from("offenders")
+    // 2. Delete roast_candidates older than 90 days
+    const { data: roastData, error: roastErr } = await supabase
+      .from("roast_candidates")
       .delete()
-      .is("last_strike", null)
       .lt("created_at", cutoffIso)
       .select("id");
-    if (err1) {
-      log.error("Failed to purge null-strike offenders", { error: err1.message });
-      throw err1;
-    }
 
-    const { data: offendersStale, error: err2 } = await supabase
+    if (roastErr) {
+      log.error("Failed to purge roast_candidates", { error: roastErr.message });
+      throw roastErr;
+    }
+    roastCandidatesDeleted = roastData?.length ?? 0;
+
+    // 3. Anonymize old offenders — preserve strike_count, hash PII (offender_id)
+    const { data: candidates, error: fetchErr } = await supabase
       .from("offenders")
-      .delete()
-      .not("last_strike", "is", null)
-      .lt("last_strike", cutoffIso)
-      .select("id");
-    if (err2) {
-      log.error("Failed to purge stale offenders", { error: err2.message });
-      throw err2;
+      .select("id, offender_id, last_strike, created_at")
+      .or(`last_strike.is.null,last_strike.lt.${cutoffIso}`)
+      .lt("created_at", cutoffIso);
+
+    if (fetchErr) throw fetchErr;
+
+    if (candidates && candidates.length > 0) {
+      const toAnonymize = (candidates as { id: string; offender_id: string }[]).filter(
+        (r) => !isAnonymized(r.offender_id),
+      );
+      if (toAnonymize.length > 0) {
+        const updates = toAnonymize.map(({ id, offender_id }) => ({
+          id,
+          offender_id: hashIdentifier(offender_id),
+          updated_at: new Date().toISOString(),
+        }));
+        const { error: updateErr } = await supabase
+          .from("offenders")
+          .upsert(updates, { onConflict: "id" });
+        if (updateErr) throw updateErr;
+        offendersAnonymized = toAnonymize.length;
+      }
     }
 
-    offendersDeleted = (offendersNull?.length ?? 0) + (offendersStale?.length ?? 0);
-
+    // 4. Purge accounts flagged for retention expiry
     const nowIso = new Date().toISOString();
     const { data: accountData, error: accountErr } = await supabase
       .from("accounts")
@@ -85,7 +114,8 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
 
     log.info("GDPR cleanup completed", {
       shieldLogsDeleted,
-      offendersDeleted,
+      roastCandidatesDeleted,
+      offendersAnonymized,
       accountsPurged,
     });
   } catch (err) {

--- a/apps/worker/src/processors/maintenance.ts
+++ b/apps/worker/src/processors/maintenance.ts
@@ -67,18 +67,28 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
     roastCandidatesDeleted = roastData?.length ?? 0;
 
     // 3. Anonymize old offenders in pages to avoid memory/payload limits.
-    //    Cursor-paginate by created_at ascending; stop when a page is empty.
+    //    Composite cursor (created_at, id) avoids skipping rows that share the
+    //    same timestamp at a page boundary.
     const PAGE_SIZE = 500;
-    let cursor = "1970-01-01T00:00:00.000Z";
+    let cursor = {
+      created_at: "1970-01-01T00:00:00.000Z",
+      id: "00000000-0000-0000-0000-000000000000",
+    };
 
     for (;;) {
+      // Fetch the next page: rows after the composite cursor, ordered by
+      // (created_at, id) so the cursor advances deterministically even when
+      // multiple rows have an identical created_at value.
       const { data: page, error: pageErr } = await supabase
         .from("offenders")
         .select("id, offender_id, created_at")
         .or(`last_strike.is.null,last_strike.lt.${cutoffIso}`)
         .lt("created_at", cutoffIso)
-        .gt("created_at", cursor)
+        .or(
+          `created_at.gt.${cursor.created_at},and(created_at.eq.${cursor.created_at},id.gt.${cursor.id})`,
+        )
         .order("created_at", { ascending: true })
+        .order("id", { ascending: true })
         .limit(PAGE_SIZE);
 
       if (pageErr) throw pageErr;
@@ -101,10 +111,11 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
         offendersAnonymized += toAnonymize.length;
       }
 
-      // Advance cursor to the last row's created_at so next page starts after it
-      cursor = (page[page.length - 1] as { created_at: string }).created_at;
+      // Advance composite cursor to the last row of this page
+      const last = page[page.length - 1] as { created_at: string; id: string };
+      cursor = { created_at: last.created_at, id: last.id };
 
-      // If we got fewer rows than the page size we've exhausted all results
+      // Fewer rows than PAGE_SIZE means no more pages remain
       if (page.length < PAGE_SIZE) break;
     }
 

--- a/apps/worker/src/processors/maintenance.ts
+++ b/apps/worker/src/processors/maintenance.ts
@@ -1,18 +1,9 @@
 import type { Job } from "bullmq";
 import { createClient } from "@supabase/supabase-js";
-import { createHash } from "crypto";
+import { hashIdentifier, isAnonymized } from "@roastr/shared";
 import { createJobLogger } from "../shared/logger.js";
 
 const RETENTION_DAYS = 90;
-const ANON_PREFIX = "anon:";
-
-function hashIdentifier(raw: string): string {
-  return ANON_PREFIX + createHash("sha256").update(raw).digest("hex").slice(0, 16);
-}
-
-function isAnonymized(value: string): boolean {
-  return value.startsWith(ANON_PREFIX);
-}
 
 export async function maintenanceProcessor(job: Job): Promise<void> {
   const log = createJobLogger("maintenance", job.id ?? "unknown");
@@ -25,12 +16,17 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
 
   const supabaseUrl = process.env.SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!supabaseUrl || !supabaseKey) {
-    const missing = [!supabaseUrl && "SUPABASE_URL", !supabaseKey && "SUPABASE_SERVICE_ROLE_KEY"]
+  const anonymizeSecret = process.env.ANONYMIZE_HMAC_KEY;
+  if (!supabaseUrl || !supabaseKey || !anonymizeSecret) {
+    const missing = [
+      !supabaseUrl && "SUPABASE_URL",
+      !supabaseKey && "SUPABASE_SERVICE_ROLE_KEY",
+      !anonymizeSecret && "ANONYMIZE_HMAC_KEY",
+    ]
       .filter(Boolean)
       .join(", ");
     log.error("Missing required environment variables", { missing });
-    throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required");
+    throw new Error(`Required environment variables missing: ${missing}`);
   }
   const supabase = createClient(supabaseUrl, supabaseKey);
 
@@ -86,7 +82,7 @@ export async function maintenanceProcessor(job: Job): Promise<void> {
       if (toAnonymize.length > 0) {
         const updates = toAnonymize.map(({ id, offender_id }) => ({
           id,
-          offender_id: hashIdentifier(offender_id),
+          offender_id: hashIdentifier(offender_id, anonymizeSecret),
           updated_at: new Date().toISOString(),
         }));
         const { error: updateErr } = await supabase

--- a/packages/shared/src/crypto/anonymize.ts
+++ b/packages/shared/src/crypto/anonymize.ts
@@ -12,6 +12,10 @@ export function hashIdentifier(raw: string, secret: string): string {
   return ANON_PREFIX + createHmac("sha256", secret).update(raw).digest("hex");
 }
 
+// HMAC-SHA256 produces 64 hex chars (256 bits); validate the full shape so
+// raw values that happen to start with "anon:" are not treated as anonymized.
+const ANONYMIZED_RE = new RegExp(`^${ANON_PREFIX}[0-9a-f]{64}$`);
+
 export function isAnonymized(value: string): boolean {
-  return value.startsWith(ANON_PREFIX);
+  return ANONYMIZED_RE.test(value);
 }

--- a/packages/shared/src/crypto/anonymize.ts
+++ b/packages/shared/src/crypto/anonymize.ts
@@ -1,0 +1,17 @@
+import { createHmac } from "crypto";
+
+export const ANON_PREFIX = "anon:";
+
+/**
+ * Produces a keyed HMAC-SHA256 digest of `raw` prefixed with ANON_PREFIX.
+ * Using HMAC (instead of plain SHA-256) makes the output non-guessable even
+ * if the input format is known, satisfying GDPR pseudonymisation requirements.
+ * The full 64-char hex digest is preserved for collision-resistance.
+ */
+export function hashIdentifier(raw: string, secret: string): string {
+  return ANON_PREFIX + createHmac("sha256", secret).update(raw).digest("hex");
+}
+
+export function isAnonymized(value: string): boolean {
+  return value.startsWith(ANON_PREFIX);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types/index.js";
+export * from "./crypto/anonymize.js";
 export * from "./domain/index.js";
 export { PLATFORM_CAPABILITIES, getPlatformCapabilities } from "./platforms/platform-capabilities.js";
 export * from "./schemas/validation.js";


### PR DESCRIPTION
## Summary

- **Retención de datos (90 días)**: `maintenanceProcessor` elimina `shield_logs` y `roast_candidates` con más de 90 días. Los `offenders` se **anonimizan** con SHA-256 (no se borran) para mantener historial de reincidencia sin PII.
- **Derecho al olvido**: `DELETE /auth/account` con cascade completo — revoca tokens OAuth (YouTube, X), elimina todos los datos en Supabase en cascade, y borra el usuario auth.
- **Transparencia IA**: `DisclaimerService` con disclaimers por plataforma (YouTube, X, default). Integrado en `RoastModule`.
- **Páginas legales**: `/privacy` y `/terms` públicas, enlazadas desde Settings > Seguridad.

## Archivos clave

| Archivo | Descripción |
|---|---|
| `apps/worker/src/processors/maintenance.ts` | Retención 90d + anonimización SHA-256 |
| `apps/api/src/modules/shield/anonymize.service.ts` | `AnonymizeService` (hashIdentifier, isAnonymized) |
| `apps/api/src/modules/auth/auth.controller.ts` | `DELETE /auth/account` con cascade |
| `apps/api/src/modules/roast/disclaimer.service.ts` | Disclaimers por plataforma |
| `apps/web/src/routes/privacy.tsx` + `terms.tsx` | Páginas legales públicas |
| `apps/api/test/auth/account-deletion.spec.ts` | Tests unitarios de borrado |

## Test plan

- [ ] `npx vitest run test/auth/account-deletion.spec.ts` — todos pasan
- [ ] `DELETE /auth/account` con contraseña incorrecta → 401
- [ ] `DELETE /auth/account` correcto → 204, cascade completo
- [ ] `/privacy` y `/terms` accesibles sin sesión
- [ ] Job mantenimiento: offenders con `offender_id` → `anon:sha256hash` tras 90 días

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion endpoint with password verification, token revocation, and cascade cleanup
  * Privacy and Terms pages (Spanish)
  * Platform-specific disclaimers for roasts; disclaimer service exposed via module
  * Roast module registered in the API

* **Chores**
  * GDPR workflow: automated anonymization, roast-candidate purge, and expanded cleanup reporting
  * Shared anonymization utilities and new env var for anonymization key
  * Maintenance worker updated to run paged anonymization and adjusted purge order

* **Tests**
  * Comprehensive tests covering account deletion scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->